### PR TITLE
Remove interpolation-only expressions

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,11 +3,11 @@
 #------------------------------------------------------------------------------
 resource "aws_iam_role" "scheduled_task_cw_event_role" {
   name               = "${var.name_preffix}-st-cw-role"
-  assume_role_policy = "${file("${path.module}/files/iam/scheduled_task_cw_event_role_assume_role_policy.json")}"
+  assume_role_policy = file("${path.module}/files/iam/scheduled_task_cw_event_role_assume_role_policy.json")
 }
 
 data "template_file" "scheduled_task_cw_event_role_cloudwatch_policy" {
-  template = "${file("${path.module}/files/iam/scheduled_task_cw_event_role_cloudwatch_policy.json")}"
+  template = file("${path.module}/files/iam/scheduled_task_cw_event_role_cloudwatch_policy.json")
   vars     = {
     TASK_EXECUTION_ROLE_ARN = var.ecs_execution_task_role_arn
   }
@@ -15,8 +15,8 @@ data "template_file" "scheduled_task_cw_event_role_cloudwatch_policy" {
 
 resource "aws_iam_role_policy" "scheduled_task_cw_event_role_cloudwatch_policy" {
   name   = "${var.name_preffix}-st-cw-policy"
-  role   = "${aws_iam_role.scheduled_task_cw_event_role.id}"
-  policy = "${data.template_file.scheduled_task_cw_event_role_cloudwatch_policy.rendered}"
+  role   = aws_iam_role.scheduled_task_cw_event_role.id
+  policy = data.template_file.scheduled_task_cw_event_role_cloudwatch_policy.rendered
 }
 
 #------------------------------------------------------------------------------
@@ -57,4 +57,3 @@ resource "aws_cloudwatch_event_target" "ecs_scheduled_task" {
     }
   }
 }
-


### PR DESCRIPTION
Fixes Terraform 0.12 warnings about Interpolation-only expressions being deprecated