### PR TITLE
Add support for ECS task role

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_ecs_cluster_arn"></a> [ecs\_cluster\_arn](#input\_ecs\_cluster\_arn) | The ECS Cluster where the scheduled task will run | `any` | n/a | yes |
 | <a name="input_ecs_execution_task_role_arn"></a> [ecs\_execution\_task\_role\_arn](#input\_ecs\_execution\_task\_role\_arn) | (Required) The task definition execution role. The Amazon Resource Name (ARN) of the IAM role to be used for this target when the rule is triggered. | `any` | n/a | yes |
+| <a name="input_ecs_task_role_arn"></a> [ecs\_task\_role\_arn](#input\_ecs\_task\_role\_arn) | (Optional) The task definition role. The Amazon Resource Name (ARN) of the IAM role to be used for this target when the rule is triggered. | `any` | `null` | no |
 | <a name="input_event_rule_description"></a> [event\_rule\_description](#input\_event\_rule\_description) | (Optional) The description of the rule. | `any` | `null` | no |
 | <a name="input_event_rule_event_bus_name"></a> [event\_rule\_event\_bus\_name](#input\_event\_rule\_event\_bus\_name) | (Optional) The event bus to associate with this rule. If you omit this, the default event bus is used. | `any` | `null` | no |
 | <a name="input_event_rule_event_pattern"></a> [event\_rule\_event\_pattern](#input\_event\_rule\_event\_pattern) | (Optional) The event pattern described a JSON object. At least one of schedule\_expression or event\_pattern is required. | `any` | `null` | no |

--- a/examples/test/main.tf
+++ b/examples/test/main.tf
@@ -30,5 +30,6 @@ module "task" {
   ecs_cluster_arn                             = module.cluster.aws_ecs_cluster_cluster_arn
   event_target_ecs_target_subnets             = module.base-network.public_subnets_ids
   event_target_ecs_target_task_definition_arn = module.td.aws_ecs_task_definition_td_arn
-  ecs_execution_task_role_arn                 = "Put your role ARN here"
+  ecs_execution_task_role_arn                 = "Put your execution role ARN here"
+  ecs_task_role_arn                           = "Put your role ARN here"
 }

--- a/main.tf
+++ b/main.tf
@@ -20,7 +20,7 @@ data "aws_iam_policy_document" "scheduled_task_cw_event_role_cloudwatch_policy" 
   }
   statement {
     actions   = ["iam:PassRole"]
-    resources = [var.ecs_execution_task_role_arn, var.ecs_task_role_arn == null ? null : var.ecs_task_role_arn]
+    resources = [var.ecs_execution_task_role_arn, var.ecs_task_role_arn]
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -20,7 +20,7 @@ data "aws_iam_policy_document" "scheduled_task_cw_event_role_cloudwatch_policy" 
   }
   statement {
     actions   = ["iam:PassRole"]
-    resources = [var.ecs_execution_task_role_arn, var.ecs_task_role_arn]
+    resources = var.ecs_task_role_arn == null ? [var.ecs_execution_task_role_arn] : [var.ecs_execution_task_role_arn, var.ecs_task_role_arn]
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -20,7 +20,7 @@ data "aws_iam_policy_document" "scheduled_task_cw_event_role_cloudwatch_policy" 
   }
   statement {
     actions   = ["iam:PassRole"]
-    resources = [var.ecs_execution_task_role_arn]
+    resources = [var.ecs_execution_task_role_arn, var.ecs_task_role_arn == null ? null : var.ecs_task_role_arn]
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -69,6 +69,11 @@ variable "ecs_execution_task_role_arn" {
   description = "(Required) The task definition execution role. The Amazon Resource Name (ARN) of the IAM role to be used for this target when the rule is triggered."
 }
 
+variable "ecs_task_role_arn" {
+  description = "(Optional) The task definition role. The Amazon Resource Name (ARN) of the IAM role to be used for this target when the rule is triggered."
+  default     = null
+}
+
 variable "event_target_ecs_target_group" {
   description = "(Optional) Specifies an ECS task group for the task. The maximum length is 255 characters."
   default     = null
@@ -104,4 +109,3 @@ variable "event_target_ecs_target_assign_public_ip" {
   description = "(Optional) Assign a public IP address to the ENI. Default false."
   type        = bool
   default     = false
-}

--- a/variables.tf
+++ b/variables.tf
@@ -71,7 +71,7 @@ variable "ecs_execution_task_role_arn" {
 
 variable "ecs_task_role_arn" {
   description = "(Optional) The task definition role. The Amazon Resource Name (ARN) of the IAM role to be used for this target when the rule is triggered."
-  default     = ""
+  default     = null
 }
 
 variable "event_target_ecs_target_group" {

--- a/variables.tf
+++ b/variables.tf
@@ -109,3 +109,4 @@ variable "event_target_ecs_target_assign_public_ip" {
   description = "(Optional) Assign a public IP address to the ENI. Default false."
   type        = bool
   default     = false
+}

--- a/variables.tf
+++ b/variables.tf
@@ -71,7 +71,7 @@ variable "ecs_execution_task_role_arn" {
 
 variable "ecs_task_role_arn" {
   description = "(Optional) The task definition role. The Amazon Resource Name (ARN) of the IAM role to be used for this target when the rule is triggered."
-  default     = null
+  default     = ""
 }
 
 variable "event_target_ecs_target_group" {


### PR DESCRIPTION
This PR adds support for (optional) usage of an ECS task role in the module.

Currently, if the provided Task Definition uses an ECS task role, the built-in IAM role will fail because it is not included in the "iam:PassRole" statement in the "scheduled_task_cw_event_role_cloudwatch_policy" IAM policy document.