### PR TITLE
add propoagte_tags option to cloudwatch event target configuration

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version = "3.50.0"
   hashes = [
     "h1:05jhjEj3Yk6hR9uhGyPGHTz/NyHYFNwcN/ywxWFGD/U=",
+    "h1:gX/faGzGvZvf9W6597S7ZcMiNI1gw9ilQwM9hkc6F2Q=",
     "zh:11d5508e180b93ab06935dbebefb08745c78ebfe1ec41d53b4340fb7f27d32eb",
     "zh:192ae31ddf1c5c4ed7f64a15c8cf3f1a440b1427fa15604e90eee40037973f0a",
     "zh:2f381b6aec131b468409416ffa1a23a15e70f2e64a554bf47da13d499a30e7e2",
@@ -22,6 +23,7 @@ provider "registry.terraform.io/hashicorp/aws" {
 provider "registry.terraform.io/hashicorp/template" {
   version = "2.2.0"
   hashes = [
+    "h1:0wlehNaxBX7GJQnPfQwTNvvAf38Jm0Nv7ssKGMaG6Og=",
     "h1:LN84cu+BZpVRvYlCzrbPfCRDaIelSyEx/W9Iwwgbnn4=",
     "zh:01702196f0a0492ec07917db7aaa595843d8f171dc195f4c988d2ffca2a06386",
     "zh:09aae3da826ba3d7df69efeb25d146a1de0d03e951d35019a0f80e4f58c89b53",

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ In order to run all checks at any point run the following command:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.50.0 |
 
 ## Modules
 
@@ -88,6 +88,7 @@ No modules.
 | <a name="input_event_target_ecs_target_assign_public_ip"></a> [event\_target\_ecs\_target\_assign\_public\_ip](#input\_event\_target\_ecs\_target\_assign\_public\_ip) | (Optional) Assign a public IP address to the ENI. Default false. | `bool` | `false` | no |
 | <a name="input_event_target_ecs_target_group"></a> [event\_target\_ecs\_target\_group](#input\_event\_target\_ecs\_target\_group) | (Optional) Specifies an ECS task group for the task. The maximum length is 255 characters. | `any` | `null` | no |
 | <a name="input_event_target_ecs_target_platform_version"></a> [event\_target\_ecs\_target\_platform\_version](#input\_event\_target\_ecs\_target\_platform\_version) | (Optional) Specifies the platform version for the task. Specify only the numeric portion of the platform version, such as 1.1.0. For more information about valid platform versions, see AWS Fargate Platform Versions. Default to LATEST | `string` | `"LATEST"` | no |
+| <a name="input_event_target_ecs_target_propagate_tags"></a> [event\_target\_ecs\_target\_propagate\_tags](#input\_event\_target\_ecs\_target\_propagate\_tags) | (Optional) Specifies whether to propagate the tags from the task definition to the task. If no value is specified, the tags are not propagated. | `bool` | `false` | no |
 | <a name="input_event_target_ecs_target_security_groups"></a> [event\_target\_ecs\_target\_security\_groups](#input\_event\_target\_ecs\_target\_security\_groups) | (Optional) The security groups associated with the task or service. If you do not specify a security group, the default security group for the VPC is used. | `list(any)` | `null` | no |
 | <a name="input_event_target_ecs_target_subnets"></a> [event\_target\_ecs\_target\_subnets](#input\_event\_target\_ecs\_target\_subnets) | The subnets associated with the task or service. | `list(any)` | n/a | yes |
 | <a name="input_event_target_ecs_target_task_count"></a> [event\_target\_ecs\_target\_task\_count](#input\_event\_target\_ecs\_target\_task\_count) | (Optional) The number of tasks to create based on the TaskDefinition. The default is 1. | `number` | `1` | no |

--- a/main.tf
+++ b/main.tf
@@ -69,6 +69,7 @@ resource "aws_cloudwatch_event_target" "ecs_scheduled_task" {
     platform_version    = var.event_target_ecs_target_platform_version
     task_count          = var.event_target_ecs_target_task_count
     task_definition_arn = var.event_target_ecs_target_task_definition_arn
+    propagate_tags      = var.event_target_ecs_target_propagate_tags
 
     network_configuration {
       subnets          = var.event_target_ecs_target_subnets

--- a/variables.tf
+++ b/variables.tf
@@ -110,3 +110,9 @@ variable "event_target_ecs_target_assign_public_ip" {
   type        = bool
   default     = false
 }
+
+variable "event_target_ecs_target_propagate_tags" {
+  description = "(Optional) Specifies whether to propagate the tags from the task definition to the task. If no value is specified, the tags are not propagated."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
this update includes changes which will add functionality to propagate tags to ecs tasks triggered by cloudwatch events.