### PR TITLE
Restrict permissions on aws_iam_policy_document

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -17,7 +17,7 @@ data "aws_iam_policy_document" "scheduled_task_cw_event_role_cloudwatch_policy" 
     effect    = "Allow"
     actions   = ["ecs:RunTask"]
     resources = ["*"]
-    condition = {
+    condition {
       test     = "ArnEquals"
       variable = "ecs:cluster"
       values   = [var.ecs_cluster_arn]

--- a/main.tf
+++ b/main.tf
@@ -17,6 +17,11 @@ data "aws_iam_policy_document" "scheduled_task_cw_event_role_cloudwatch_policy" 
     effect    = "Allow"
     actions   = ["ecs:RunTask"]
     resources = ["*"]
+    condition = {
+      test     = "ArnEquals"
+      variable = "ecs:cluster"
+      values   = [var.ecs_cluster_arn]
+    }
   }
   statement {
     actions   = ["iam:PassRole"]


### PR DESCRIPTION
The event rule should have right to run tasks only on the concerned ECS cluster.
